### PR TITLE
Handle findfirst / findlast change

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 MultivariatePolynomials 0.1.0
+Nullables

--- a/src/DynamicPolynomials.jl
+++ b/src/DynamicPolynomials.jl
@@ -7,6 +7,8 @@ import Base: length, getindex, vect, isless, isempty, start, done, next, convert
 using MultivariatePolynomials
 const MP = MultivariatePolynomials
 
+using Nullables
+
 #const PolyType{C} = Union{DMonomialLike{C}, RationalPoly{C}}
 #iscomm(::PolyType{C}) where {C} = C
 #zero(p::PolyType{C}) where {C} = zero(typeof(p))

--- a/src/cmult.jl
+++ b/src/cmult.jl
@@ -8,7 +8,7 @@ function (*)(x::PolyVar{true}, y::PolyVar{true})
 end
 function multiplyvar(v::Vector{PolyVar{true}}, x::PolyVar{true})
     i = findfirst(w->w <= x, v)
-    if i > 0 && v[i] == x
+    if (i != nothing && i > 0) && v[i] == x
         multiplyexistingvar(v, x, i)
     else
         insertvar(v, x, i == 0 ? length(v)+1 : i)

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -1,6 +1,6 @@
 function MP.differentiate(m::Monomial{C}, x::PolyVar{C}) where C
     i = findfirst(_vars(m), x)
-    if i == 0 || m.z[i] == 0
+    if (i == nothing || i == 0) || m.z[i] == 0
         zeroterm(m)
     else
         z = copy(m.z)
@@ -13,7 +13,7 @@ function MP.differentiate(p::Polynomial{C, T}, x::PolyVar{C}) where {C, T}
     # grlex order preserved
     i = findfirst(_vars(p), x)
     S = Base.promote_op(*, T, Int)
-    if i == 0
+    if i == nothing || i == 0
         zero(Polynomial{C, S})
     else
         keep = find([z[i] > 0 for z in p.x.Z])

--- a/src/ncmult.jl
+++ b/src/ncmult.jl
@@ -96,11 +96,11 @@ end
 
 function (*)(x::Monomial{false}, y::Monomial{false})
     i = findlast(z -> z > 0, x.z)
-    if i == 0
+    if i == nothing || i == 0
         return y
     end
     j = findfirst(z -> z > 0, y.z)
-    if j == 0
+    if j == nothing || j == 0
         return x
     end
     if x.vars[i] == y.vars[j]

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -1,8 +1,9 @@
 function fillmap!(vals, vars, s::MP.Substitution)
     j = findfirst(vars, s.first)
+    # 0.6 behaviour:
     # If j == 0, that means that the variable is not present
     # so it is ignored
-    if j > 0
+    if j!= nothing && j > 0
       vals[j] = s.second
     end
 end


### PR DESCRIPTION
Previously findfirst and findlast returned 0 if for no entry the
predicate returned `true`. Now it returns `nothing`. The changes should be backwards compatible to 0.6.
Locally the tests segfault, maybe it works on travis 🤷‍♂️ 