### PR TITLE
Disable OSX on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: julia
 os:
   - linux
-  - osx
+  # - osx
 julia:
   - 0.6
   - nightly


### PR DESCRIPTION
The MacOS cluster from travis seems to be quite unreliable / needs a looooot of time. Since there is no system specific stuff here I think it is fine to only run linux.