### PR TITLE
Avoid unnecessary compilation for similarvariable

### DIFF
--- a/src/DynamicPolynomials.jl
+++ b/src/DynamicPolynomials.jl
@@ -39,6 +39,7 @@ _vars(p::AbstractArray{<:PolyType}) = mergevars(_vars.(p))[1]
 MP.variables(p::Union{PolyType, MonomialVector, AbstractArray{<:PolyType}}) = _vars(p) # tuple(_vars(p))
 MP.nvariables(p::Union{PolyType, MonomialVector, AbstractArray{<:PolyType}}) = length(_vars(p))
 MP.similarvariable(p::Union{PolyType{C}, Type{<:PolyType{C}}}, ::Type{Val{V}}) where {C, V} = PolyVar{C}(string(V))
+MP.similarvariable(p::Union{PolyType{C}, Type{<:PolyType{C}}}, V::Symbol) where {C} = PolyVar{C}(string(V))
 include("promote.jl")
 
 include("operators.jl")


### PR DESCRIPTION
Directly dispatch on the `similarvariable(f, symb)` constructor.
Previously the symbol was wrapped in a `Val` and thus forced compilation
for each new symbol.

Before
```julia
@time MP.similarvariable(f, gensym(:x0))
0.004129 seconds (289 allocations: 16.340 KiB)
##x0#687
```
Now
```julia
@time MP.similarvariable(f, gensym(:x0))
  0.000017 seconds (14 allocations: 608 bytes)
##x0#688

```