### PR TITLE
Add default evaluations routines which assume default variable ordering

### DIFF
--- a/src/subs.jl
+++ b/src/subs.jl
@@ -96,3 +96,14 @@ end
 (m::Monomial)(s::MP.AbstractSubstitution...)   = MP.substitute(MP.Eval(), m, s)
 (t::Term)(s::MP.AbstractSubstitution...)       = MP.substitute(MP.Eval(), t, s)
 (p::Polynomial)(s::MP.AbstractSubstitution...) = MP.substitute(MP.Eval(), p, s)
+
+(p::PolyVar)(x::Number) = x
+(p::Monomial)(x::NTuple{N, <:Number}) where N = MP.substitute(MP.Eval(), p, variables(p)=>x)
+(p::Monomial)(x::AbstractVector{<:Number}) = MP.substitute(MP.Eval(), p, variables(p)=>x)
+(p::Monomial)(x::Number...) = MP.substitute(MP.Eval(), p, variables(p)=>x)
+(p::Term)(x::NTuple{N, <:Number}) where N = MP.substitute(MP.Eval(), p, variables(p)=>x)
+(p::Term)(x::AbstractVector{<:Number}) = MP.substitute(MP.Eval(), p, variables(p)=>x)
+(p::Term)(x::Number...) = MP.substitute(MP.Eval(), p, variables(p)=>x)
+(p::Polynomial)(x::NTuple{N, <:Number}) where N = MP.substitute(MP.Eval(), p, variables(p)=>x)
+(p::Polynomial)(x::AbstractVector{<:Number}) = MP.substitute(MP.Eval(), p, variables(p)=>x)
+(p::Polynomial)(x::Number...) = MP.substitute(MP.Eval(), p, variables(p)=>x)

--- a/test/mono.jl
+++ b/test/mono.jl
@@ -94,4 +94,13 @@
         @test variables(m) == [x, y, z, x, y]
         @test m.z == [2, 1, 1, 0, 0]
     end
+
+    @testset "Evaluation" begin
+        @polyvar x y
+        @test (x^2*y)(3,2) == 18
+        @test (x^2*y)((3,2)) == 18
+        @test (x^2*y)([3,2]) == 18
+        @test (x^2)(3) == 9
+        @test (x)(3) == 3
+    end
 end

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -64,4 +64,15 @@
         @inferred polynomial(2u)
         @inferred polynomial(2.0u, Int)
     end
+
+    @testset "Evaluation" begin
+        @polyvar x y
+        @test (x^2+y^3)(2, 3) == 31
+        @test (x^2+y^3)((2, 3)) == 31
+        @test (x^2+y^3)([2, 3]) == 31
+        @test (2x^2*y)(3,2) == 36
+        @test (2x^2*y)((3,2)) == 36
+        @test (2x^2*y)([3,2]) == 36
+        @test (2x^2)(3) == 18
+    end
 end


### PR DESCRIPTION
If I have to evaluate DynamicPolynomials in 99% of my cases I end up doing
```julia
f(MP.variables(f)=>x)
```
This PR adds more callable cases to support
```julia
f(1, 2) # fallback  to  f(MP.variables(f)=>(1, 2))
f((1, 2))  # fallback  to  f(MP.variables(f)=>(1, 2))
f([1, 2])  # fallback  to  f(MP.variables(f)=>[1, 2])
```

I don't think that this leads to substantially more confusion than the current requirement to always explicitly provide the variables.