### PR TITLE
Update to 0.7 (only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ os:
   - linux
   # - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
+
+matrix:
+ allow_failures:
+ - julia: nightly
+
 notifications:
   email: false
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.6
 MultivariatePolynomials 0.1.3
-Nullables
 Compat 0.70

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6
+julia 0.7
 MultivariatePolynomials 0.1.3
-Compat 0.70

--- a/src/DynamicPolynomials.jl
+++ b/src/DynamicPolynomials.jl
@@ -1,7 +1,5 @@
 module DynamicPolynomials
 
-using Compat
-
 using MultivariatePolynomials
 const MP = MultivariatePolynomials
 

--- a/src/DynamicPolynomials.jl
+++ b/src/DynamicPolynomials.jl
@@ -5,8 +5,6 @@ using Compat
 using MultivariatePolynomials
 const MP = MultivariatePolynomials
 
-using Nullables
-
 # Exports which should be available for an enduser
 import MultivariatePolynomials: differentiate, variables, subs, maxdegree, mindegree
 export differentiate, variables, subs, maxdegree, mindegree

--- a/src/DynamicPolynomials.jl
+++ b/src/DynamicPolynomials.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module DynamicPolynomials
 
 using Compat

--- a/src/monovec.jl
+++ b/src/monovec.jl
@@ -49,9 +49,10 @@ Base.endof(x::MonomialVector) = length(x)
 Base.size(x::MonomialVector) = (length(x),)
 Base.length(x::MonomialVector) = length(x.Z)
 Base.isempty(x::MonomialVector) = length(x) == 0
-Base.start(::MonomialVector) = 1
-Base.done(x::MonomialVector, state) = length(x) < state
-Base.next(x::MonomialVector, state) = (x[state], state+1)
+Base.iterate(x::MonomialVector) = isempty(x) ? nothing : (x[1], 1)
+function Base.iterate(x::MonomialVector, state::Int)
+    state < length(x) ? (x[state+1], state+1) : nothing
+end
 
 MultivariatePolynomials.extdegree(x::MonomialVector) = isempty(x) ? (0, 0) : extrema(sum.(x.Z))
 MultivariatePolynomials.mindegree(x::MonomialVector) = isempty(x) ? 0 : minimum(sum.(x.Z))

--- a/src/monovec.jl
+++ b/src/monovec.jl
@@ -219,19 +219,21 @@ function MP.mergemonovec(ms::Vector{MonomialVector{C}}) where {C}
     L = length.(ms)
     X = Vector{Monomial{C}}()
     while any(I .<= L)
-        max = Nullable{Monomial{C}}()
+        max = nothing
         for i in 1:m
             if I[i] <= L[i]
                 x = ms[i][I[i]]
-                if isnull(max) || get(max) < x
-                    max = Nullable(x)
+                if max === nothing || max < x
+                    max = x
                 end
             end
         end
-        @assert !isnull(max)
-        push!(X, get(max))
+        @assert max !== nothing
+        # to ensure that max is no more a union
+        max === nothing && return X
+        push!(X, max)
         for i in 1:m
-            if I[i] <= L[i] && get(max) == ms[i][I[i]]
+            if I[i] <= L[i] && max == ms[i][I[i]]
                 I[i] += 1
             end
         end

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -75,9 +75,10 @@ Polynomial{C}(f::Function, x) where {C} = Polynomial{C, Base.promote_op(f, Int)}
 
 Base.length(p::Polynomial) = length(p.a)
 Base.isempty(p::Polynomial) = isempty(p.a)
-Base.start(::Polynomial) = 1
-Base.done(p::Polynomial, state) = length(p) < state
-Base.next(p::Polynomial, state) = (p[state], state+1)
+Base.iterate(p::Polynomial) = isempty(p) ? nothing : (p[1], 1)
+function Base.iterate(p::Polynomial, state::Int)
+    state < length(p) ? (p[state+1], state+1) : nothing
+end
 #eltype(::Type{Polynomial{C, T}}) where {C, T} = T
 Base.getindex(p::Polynomial, I::Int) = Term(p.a[I[1]], p.x[I[1]])
 
@@ -90,9 +91,11 @@ Base.endof(p::TermIterator) = length(p.p)
 Base.length(p::TermIterator) = length(p.p.a)
 Base.size(p::TermIterator) = (length(p),)
 Base.isempty(p::TermIterator) = isempty(p.p.a)
-Base.start(::TermIterator) = 1
-Base.done(p::TermIterator, state) = length(p.p) < state
-Base.next(p::TermIterator, state) = (p.p[state], state+1)
+Base.iterate(p::TermIterator) = isempty(p) ? nothing : (p[1], 1)
+function Base.iterate(p::TermIterator, state::Int)
+    state < length(p) ? (p[state+1], state+1) : nothing
+end
+
 Base.getindex(p::TermIterator, I::Int) = Term(p.p.a[I[1]], p.p.x[I[1]])
 
 MP.terms(p::Polynomial) = TermIterator(p)

--- a/src/var.jl
+++ b/src/var.jl
@@ -31,10 +31,10 @@ end
 
 # Variable vector x returned garanteed to be sorted so that if p is built with x then vars(p) == x
 macro polyvar(args...)
-    Compat.reduce((x,y) -> :($x; $y), [buildpolyvar(PolyVar{true}, arg) for arg in args], init=:())
+    reduce((x,y) -> :($x; $y), [buildpolyvar(PolyVar{true}, arg) for arg in args], init=:())
 end
 macro ncpolyvar(args...)
-    Compat.reduce((x,y) -> :($x; $y), [buildpolyvar(PolyVar{false}, arg) for arg in args], init=:())
+    reduce((x,y) -> :($x; $y), [buildpolyvar(PolyVar{false}, arg) for arg in args], init=:())
 end
 
 struct PolyVar{C} <: AbstractVariable

--- a/test/mvp.jl
+++ b/test/mvp.jl
@@ -1,5 +1,6 @@
 using Compat.Pkg
-const mvp_test = joinpath(Pkg.dir("MultivariatePolynomials"), "test")
+import MultivariatePolynomials
+const mvp_test = joinpath(dirname(pathof(MultivariatePolynomials)), "..", "test")
 const Mod = DynamicPolynomials
 const MP = MultivariatePolynomials
 include(joinpath(mvp_test, "utils.jl"))

--- a/test/mvp.jl
+++ b/test/mvp.jl
@@ -1,4 +1,4 @@
-using Compat.Pkg
+using Pkg
 import MultivariatePolynomials
 const mvp_test = joinpath(dirname(pathof(MultivariatePolynomials)), "..", "test")
 const Mod = DynamicPolynomials

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using DynamicPolynomials
 using MultivariatePolynomials
 using Compat
 using Compat.Test
+using Compat.LinearAlgebra
 
 include("mono.jl")
 include("poly.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,14 @@
 using DynamicPolynomials
 using MultivariatePolynomials
-using Compat
-using Compat.Test
-using Compat.LinearAlgebra
+using Test
+using LinearAlgebra
 
 include("mono.jl")
 include("poly.jl")
 include("comp.jl")
 
 module newmodule
-    using Compat
-    using Compat.Test
+    using Test
     import DynamicPolynomials
     @testset "Polyvar macro hygiene" begin
         # Verify that the @polyvar macro works when the package has been activated


### PR DESCRIPTION
This updates the package to work without any deprecation warnings with Julia `0.7-rc2.0`. There is a [parallel update for MultivariatePolynomials](https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/pull/89). 