### PR TITLE
Fix errors on 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   # - osx
 julia:
   - 0.7
+  - 1.0
   - nightly
 
 matrix:

--- a/src/monovec.jl
+++ b/src/monovec.jl
@@ -45,7 +45,8 @@ function Base.getindex(x::MV, I) where {MV<:MonomialVector}
 end
 Base.getindex(x::MonomialVector, i::Integer) = Monomial(x.vars, x.Z[i])
 
-Base.endof(x::MonomialVector) = length(x)
+Base.firstindex(x::MonomialVector) = firstindex(x.Z)
+Base.lastindex(x::MonomialVector) = lastindex(x.Z)
 Base.size(x::MonomialVector) = (length(x),)
 Base.length(x::MonomialVector) = length(x.Z)
 Base.isempty(x::MonomialVector) = length(x) == 0

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -88,7 +88,8 @@ Base.getindex(p::Polynomial, I::Int) = Term(p.a[I[1]], p.x[I[1]])
 struct TermIterator{C, T} <: AbstractVector{Term{C, T}}
     p::Polynomial{C, T}
 end
-Base.endof(p::TermIterator) = length(p.p)
+Base.firstindex(p::TermIterator) = firstindex(p.p.a)
+Base.lastindex(p::TermIterator) = lastindex(p.p.a)
 Base.length(p::TermIterator) = length(p.p.a)
 Base.size(p::TermIterator) = (length(p),)
 Base.isempty(p::TermIterator) = isempty(p.p.a)


### PR DESCRIPTION
It seems that 0.7 had no deprecation warning for `Base.endof`. With this change everything works on Julia 1.0 🎉 