### PR TITLE
remove emptymonovec method for tuples of polyvars

### DIFF
--- a/src/monovec.jl
+++ b/src/monovec.jl
@@ -67,7 +67,6 @@ const DMonoVecElemNonConstant{C} = Union{PolyVar{C}, Monomial{C}, Term{C}}
 const DMonoVecElem{C} = Union{Int, DMonoVecElemNonConstant{C}}
 const DMonoVec{C} = AbstractVector{<:DMonoVecElem{C}}
 
-MP.emptymonovec(vars::NTuple{N, PolyVar{C}}) where {N, C} = MonomialVector{C}(collect(vars), Vector{Int}[])
 MP.emptymonovec(vars::AbstractVector{PolyVar{C}}) where {C} = MonomialVector{C}(vars, Vector{Int}[])
 MP.emptymonovec(t::DMonoVecElemNonConstant) = emptymonovec(_vars(t))
 MP.emptymonovec(::Type{<:DMonoVecElemNonConstant{C}}) where {C} = MonomialVector{C}()

--- a/src/monovec.jl
+++ b/src/monovec.jl
@@ -67,7 +67,8 @@ const DMonoVecElemNonConstant{C} = Union{PolyVar{C}, Monomial{C}, Term{C}}
 const DMonoVecElem{C} = Union{Int, DMonoVecElemNonConstant{C}}
 const DMonoVec{C} = AbstractVector{<:DMonoVecElem{C}}
 
-MP.emptymonovec(vars::VarVec{C}) where {C} = MonomialVector{C}(vars, Vector{Int}[])
+MP.emptymonovec(vars::NTuple{N, PolyVar{C}}) where {N, C} = MonomialVector{C}(collect(vars), Vector{Int}[])
+MP.emptymonovec(vars::AbstractVector{PolyVar{C}}) where {C} = MonomialVector{C}(vars, Vector{Int}[])
 MP.emptymonovec(t::DMonoVecElemNonConstant) = emptymonovec(_vars(t))
 MP.emptymonovec(::Type{<:DMonoVecElemNonConstant{C}}) where {C} = MonomialVector{C}()
 

--- a/src/var.jl
+++ b/src/var.jl
@@ -71,8 +71,6 @@ _vars(v::PolyVar) = [v]
 
 iscomm(::Type{PolyVar{C}}) where {C} = C
 
-const VarVec{C} = Union{AbstractVector{PolyVar{C}}, NTuple{<:Integer, PolyVar{C}}}
-
 function mergevars(varsvec::Vector{Vector{PV}}) where {PV<:PolyVar}
     n = length(varsvec)
     is = ones(Int, n)


### PR DESCRIPTION
Addresses #43.

However `emptymonovec` isn't implemented in TypedPolynomials yet.