### PR TITLE
Copy internal vectors instead of giving the same instance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 DataStructures = "0.17"
-MultivariatePolynomials = "~0.3.3"
+MultivariatePolynomials = "0.3.4"
 MutableArithmetics = "0.1.1"
 Reexport = "0.2"
 julia = "1"

--- a/src/cmult.jl
+++ b/src/cmult.jl
@@ -57,8 +57,7 @@ function multdivmono!(output_variables::Vector{PolyVar{true}},
 end
 function multdivmono(v::Vector{PolyVar{true}}, x::Monomial{true}, op)
     if v == x.vars
-        # /!\ no copy done here for efficiency, do not mess up with vars
-        w = v
+        w = copy(v)
         updatez = z -> op.(z, x.z)
     else
         w, maps = mergevars([v, x.vars])


### PR DESCRIPTION
Doing `MA.operate!(op(p, q), ...)` could modify `p` or `q` as some vectors were not copied. This PR fixes this.