### PR TITLE
Close issue #62

### DIFF
--- a/src/mono.jl
+++ b/src/mono.jl
@@ -11,7 +11,7 @@ struct Monomial{C} <: AbstractMonomial
 
     function Monomial{C}(vars::Vector{PolyVar{C}}, z::Vector{Int}) where {C}
         if length(vars) != length(z)
-            throw(ArgumentError("There should be as many vars than exponents"))
+            throw(ArgumentError("There should be as many variables as exponents"))
         end
         new(vars, z)
     end

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -23,8 +23,8 @@ MA.mutable_copy(p::Polynomial{C, T}) where {C, T} = Polynomial{C, T}(MA.mutable_
 Base.copy(p::Polynomial) = MA.mutable_copy(p)
 Base.zero(::Type{Polynomial{C, T}}) where {C, T} = Polynomial(T[], MonomialVector{C}())
 Base.one(::Type{Polynomial{C, T}}) where {C, T} = Polynomial([one(T)], MonomialVector{C}(PolyVar{C}[], [Int[]]))
-Base.zero(p::Polynomial{C, T}) where {C, T} = Polynomial(T[], emptymonovec(_vars(p)))
-Base.one(p::Polynomial{C, T}) where {C, T} = Polynomial([one(T)], MonomialVector(_vars(p), [zeros(Int, nvariables(p))]))
+Base.zero(p::Polynomial{C, T}) where {C, T} = Polynomial(T[], emptymonovec(copy(_vars(p))))
+Base.one(p::Polynomial{C, T}) where {C, T} = Polynomial([one(T)], MonomialVector(copy(_vars(p)), [zeros(Int, nvariables(p))]))
 
 Polynomial{C, T}(a::AbstractVector, x::MonomialVector) where {C, T} = Polynomial{C, T}(Vector{T}(a), x)
 Polynomial{C, T}(a::AbstractVector, X::DMonoVec) where {C, T} = Polynomial{C, T}(monovec(a, X)...)

--- a/test/mutable_arithmetics.jl
+++ b/test/mutable_arithmetics.jl
@@ -27,4 +27,13 @@ using DynamicPolynomials
     @test nterms(p) == 10
     @test issorted(monomials(p), rev=true)
     @test p == T(2)x^3 + T(5)x^2 + T(4)x * y + T(4)y^2 + T(5)x + T(2) + q
+
+    @testset "Issue #62" begin
+        @polyvar x y
+        p = x^2 + x + 1
+        q = rem(p, [x^2-y])
+        @test q == x + y + 1 
+    end
 end
+
+


### PR DESCRIPTION
When generating a polynomial `q = zero(p)`, using mutable operations on `p` had an impact on `q`. This is should be fixed now. 
In particular 
```julia
@polyvar x y
p = x^2 + x + 1
q = rem(p, [x^2-y])
```
throws an error without this fix.