### PR TITLE
Support VT("name") where VT::Type{<:Variable}

### DIFF
--- a/src/var.jl
+++ b/src/var.jl
@@ -118,6 +118,9 @@ struct Variable{V,M} <: AbstractVariable
     name::String
     variable_order::V
 
+    function Variable{V,M}(name::AbstractString) where {V<:AbstractVariableOrdering,M<:MP.AbstractMonomialOrdering}
+        return new{V,M}(convert(String, name), instantiate(V))
+    end
     function Variable(
         name::AbstractString,
         ::Type{V},

--- a/test/mono.jl
+++ b/test/mono.jl
@@ -15,6 +15,9 @@ import MultivariatePolynomials as MP
         @test size(u) == (3, 2)
         @test x[1] > x[2] > x[3] > y > z[1] > z[2]
         @test u[1, 1] > u[2, 1] > u[2, 2]
+        dummy = VT("dummy")
+        @test dummy isa VT
+        @test name(dummy) == "dummy"
 
         @polyvar a[1:5, 1:3, 1:2]
         @test size(a) == (5, 3, 2)


### PR DESCRIPTION
Rather than creating a variable with `Variable(name, V, M)`,
sometimes it's easier to create one with `Variable{V,M}(name)`.
This allows one to create a new variable from an old one with
`typeof(oldvar)(newname)`.