### PR TITLE
`MA.operate!(+, pol1, pol2)`: prevent captured variable perf issue

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -154,8 +154,9 @@ function MA.operate!(
         push!(p.a, t[1])
         return push!(p.x.Z, t[2])
     end
-    compare_monomials(t::_NoVarTerm, j::Int) = _exponents_compare(q, j, t[2])
-    compare_monomials(i::Int, j::Int) = compare_monomials(get1(i), j)
+    compare_monomials_impl(t, j) = _exponents_compare(q, j, t[2])
+    compare_monomials(t::_NoVarTerm, j::Int) = compare_monomials_impl(t, j)
+    compare_monomials(i::Int, j::Int) = compare_monomials_impl(get1(i), j)
     combine(i::Int, j::Int) = p.a[i] = MA.operate!!(op, p.a[i], q.a[j])
     combine(t::_NoVarTerm, j::Int) = (MA.operate!!(op, t[1], q.a[j]), t[2])
     function resize(n)


### PR DESCRIPTION
The local function was spuriously recursive, making it not recursive fixes the performance problem. That is, this removes some run time dispatch and decreases the amount of allocation, but there's still some run time dispatch left in other places, according to JET.jl.

Before:

```julia-repl
julia> import MutableArithmetics; const MA = MutableArithmetics;

julia> using DynamicPolynomials

julia> @polyvar x y;

julia> p = 2x + y;

julia> q = x + 2y;

julia> @allocated MA.operate!(+, p, q)
34413936
```

After:

```julia-repl
julia> import MutableArithmetics; const MA = MutableArithmetics;

julia> using DynamicPolynomials

julia> @polyvar x y;

julia> p = 2x + y;

julia> q = x + 2y;

julia> @allocated MA.operate!(+, p, q)
30835632
```

Both REPL runs was with nightly Julia v1.11.