### PR TITLE
A fix for ordering(poly)

### DIFF
--- a/src/var.jl
+++ b/src/var.jl
@@ -145,7 +145,8 @@ end
 
 MP.monomial(v::Variable) = Monomial(v)
 MP.variables(v::Variable) = [v]
-MP.ordering(::Variable{V,M}) where {V,M} = M
+MP.ordering(v::Variable) = MP.ordering(typeof(v))
+MP.ordering(::Type{Variable{V,M}}) where {V,M} = M
 
 iscomm(::Type{Variable{C}}) where {C} = C
 


### PR DESCRIPTION
@blegat thanks for the quick fix. 
Looks like `ordering` for polynomials would still not work, this is a quick fix.