### PR TITLE
Add antidifferentiation

### DIFF
--- a/src/DynamicPolynomials.jl
+++ b/src/DynamicPolynomials.jl
@@ -84,6 +84,7 @@ include("promote.jl")
 include("operators.jl")
 include("comp.jl")
 
+include("anti_diff.jl")
 include("diff.jl")
 include("subs.jl")
 

--- a/src/anti_diff.jl
+++ b/src/anti_diff.jl
@@ -8,3 +8,19 @@ function MP.antidifferentiate(m::Monomial{V,M}, x::Variable{V,M}) where {V,M}
         Monomial(MP.variables(m), z) / (m.z[i] + 1)
     end
 end
+
+function MP.antidifferentiate(p::Polynomial{V,M,T}, x::Variable{V,M}) where {V,M,T}
+    i = something(findfirst(isequal(x), MP.variables(p)), 0)
+    S = typeof(zero(T) * 0)
+    if iszero(i)
+        x * p
+    else
+        Z = copy.(p.x.Z)
+        a = Vector{S}(undef, length(p.a))
+        for j in 1:length(Z)
+            a[j] = p.a[j] / (Z[j][i] + 1)
+            Z[j][i] += 1
+        end
+        Polynomial(a, MonomialVector(MP.variables(p), Z))
+    end
+end

--- a/src/anti_diff.jl
+++ b/src/anti_diff.jl
@@ -1,3 +1,11 @@
+function _div_by_power(x::T, y::Int) where {T}
+    x / y
+end
+
+function _div_by_power(x::T, y::Int)::Rational{T} where {T<:Int}
+    x // y
+end
+
 function MP.antidifferentiate(m::Monomial{V,M}, x::Variable{V,M}) where {V,M}
     z = copy(m.z)
     i = findfirst(isequal(x), MP.variables(m))
@@ -11,14 +19,14 @@ end
 
 function MP.antidifferentiate(p::Polynomial{V,M,T}, x::Variable{V,M}) where {V,M,T}
     i = something(findfirst(isequal(x), MP.variables(p)), 0)
-    S = typeof(zero(T) * 0)
+    S = typeof(_div_by_power(zero(T), Int(1)))
     if iszero(i)
         x * p
     else
         Z = copy.(p.x.Z)
         a = Vector{S}(undef, length(p.a))
         for j in 1:length(Z)
-            a[j] = p.a[j] / (Z[j][i] + 1)
+            a[j] = _div_by_power(p.a[j], (Z[j][i] + 1))
             Z[j][i] += 1
         end
         Polynomial(a, MonomialVector(MP.variables(p), Z))

--- a/src/anti_diff.jl
+++ b/src/anti_diff.jl
@@ -2,7 +2,7 @@ function _div_by_power(x::T, y::Int) where {T}
     x / y
 end
 
-function _div_by_power(x::T, y::Int)::Rational{T} where {T<:Int}
+function _div_by_power(x::T, y::Int)::Rational{T} where {T<:Integer}
     x // y
 end
 

--- a/src/anti_diff.jl
+++ b/src/anti_diff.jl
@@ -1,0 +1,10 @@
+function MP.antidifferentiate(m::Monomial{V,M}, x::Variable{V,M}) where {V,M}
+    z = copy(m.z)
+    i = findfirst(isequal(x), MP.variables(m))
+    if (i === nothing || i == 0) || m.z[i] == 0
+        Monomial(MP.variables(m), z) * x
+    else
+        z[i] += 1
+        Monomial(MP.variables(m), z) / (m.z[i] + 1)
+    end
+end

--- a/src/anti_diff.jl
+++ b/src/anti_diff.jl
@@ -13,7 +13,7 @@ function MP.antidifferentiate(m::Monomial{V,M}, x::Variable{V,M}) where {V,M}
         Monomial(MP.variables(m), z) * x
     else
         z[i] += 1
-        Monomial(MP.variables(m), z) / (m.z[i] + 1)
+        (1 // (m.z[i] + 1)) * Monomial(MP.variables(m), z)
     end
 end
 

--- a/test/mono.jl
+++ b/test/mono.jl
@@ -141,6 +141,24 @@ import MultivariatePolynomials as MP
         @test m.z == [2, 1, 1, 0, 0]
     end
 
+    @testset "Antidifferentiation" begin
+	      @ncpolyvar x y z
+
+        @info typeof(x)
+
+        m = x
+        mi = DynamicPolynomials.MP.antidifferentiate(m, y)
+        @test mi == x * y
+
+        m = x^3
+        mi = DynamicPolynomials.MP.antidifferentiate(m, x)
+        @test mi == (x^4 / 4)
+
+        m = Monomial([x, y, z], [1, 2, 3])
+        mi = DynamicPolynomials.MP.antidifferentiate(m, z)
+        @test mi == (x*y^2*z^4) / 4
+    end
+
     @testset "Evaluation" begin
         @polyvar x y
         @test (x^2 * y)(3, 2) == 18

--- a/test/mono.jl
+++ b/test/mono.jl
@@ -144,8 +144,6 @@ import MultivariatePolynomials as MP
     @testset "Antidifferentiation" begin
 	      @ncpolyvar x y z
 
-        @info typeof(x)
-
         m = x
         mi = DynamicPolynomials.MP.antidifferentiate(m, y)
         @test mi == x * y

--- a/test/mono.jl
+++ b/test/mono.jl
@@ -148,13 +148,19 @@ import MultivariatePolynomials as MP
         mi = DynamicPolynomials.MP.antidifferentiate(m, y)
         @test mi == x * y
 
+        # Antidifferentiation is product => Integral coefficients
+        @test MP.coefficient_type(mi) == Int
+
+        # General antidifferentiation => Rational coefficients
         m = x^3
         mi = DynamicPolynomials.MP.antidifferentiate(m, x)
         @test mi == (x^4 / 4)
+        @test MP.coefficient_type(mi) == Rational{Int}
 
         m = Monomial([x, y, z], [1, 2, 3])
         mi = DynamicPolynomials.MP.antidifferentiate(m, z)
         @test mi == (x*y^2*z^4) / 4
+        @test MP.coefficient_type(mi) == Rational{Int}
     end
 
     @testset "Evaluation" begin

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -81,6 +81,22 @@
         @inferred polynomial(2.0u, Int)
     end
 
+    @testset "Antiderivative" begin
+        @polyvar x y
+
+        p = (x^2 + 4*y^3)
+        pi = DynamicPolynomials.antidifferentiate(p, y)
+        @test pi == (x^2*y + y^4)
+
+        p = 2*y
+        pi = DynamicPolynomials.antidifferentiate(p, y)
+        @test pi == y^2
+
+        p = x^2
+        pi = DynamicPolynomials.antidifferentiate(p, y)
+        @test pi == x^2*y
+    end
+
     @testset "Evaluation" begin
         @polyvar x y
         @test (x^2 + y^3)(2, 3) == 31

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -84,17 +84,33 @@
     @testset "Antiderivative" begin
         @polyvar x y
 
-        p = (x^2 + 4*y^3)
-        pi = DynamicPolynomials.antidifferentiate(p, y)
-        @test pi == (x^2*y + y^4)
+        p = (x^2 + 4 * y^3)
+        (_, _, T) = typeof(p).parameters
+        @test T == Int
 
-        p = 2*y
+        pi = DynamicPolynomials.antidifferentiate(p, y)
+        @test pi == (x^2 * y + y^4)
+
+        pi = DynamicPolynomials.antidifferentiate(p, x)
+        (_, _, T) = typeof(pi).parameters
+        @test T == Rational{Int}
+
+        p = (1.0 * x^2 + 2.0 * y^2)
+        (_, _, T) = typeof(p).parameters
+        @test T == Float64
+
+        pi = DynamicPolynomials.antidifferentiate(p, x)
+        (_, _, T) = typeof(pi).parameters
+        @test T == Float64
+
+        p = 2 * y
         pi = DynamicPolynomials.antidifferentiate(p, y)
         @test pi == y^2
 
         p = x^2
         pi = DynamicPolynomials.antidifferentiate(p, y)
-        @test pi == x^2*y
+        @test pi == x^2 * y
+
     end
 
     @testset "Evaluation" begin

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -85,23 +85,19 @@
         @polyvar x y
 
         p = (x^2 + 4 * y^3)
-        (_, _, T) = typeof(p).parameters
-        @test T == Int
+        @test MP.coefficient_type(p) == Int
 
         pi = DynamicPolynomials.antidifferentiate(p, y)
         @test pi == (x^2 * y + y^4)
 
         pi = DynamicPolynomials.antidifferentiate(p, x)
-        (_, _, T) = typeof(pi).parameters
-        @test T == Rational{Int}
+        @test MP.coefficient_type(pi) == Rational{Int}
 
         p = (1.0 * x^2 + 2.0 * y^2)
-        (_, _, T) = typeof(p).parameters
-        @test T == Float64
+        @test MP.coefficient_type(p) == Float64
 
         pi = DynamicPolynomials.antidifferentiate(p, x)
-        (_, _, T) = typeof(pi).parameters
-        @test T == Float64
+        @test MP.coefficient_type(pi) == Float64
 
         p = 2 * y
         pi = DynamicPolynomials.antidifferentiate(p, y)


### PR DESCRIPTION
This patch adds an implementation of the `antidifferentiate` function for both monomials and polynomials (fixing #157).

The function `antidifferentiate(p, x)` works by either returning the product `p*x` if `p` has no term with variable `x`, or by incrementing the powers and adjusting the coefficients to match (thereby always ensuring that the antiderivative evaluates to zero whenever `x` is zero).

I included some basic unit tests as well. I did not run `JuliaFormatter.jl` over the codebase, since numerous other files are not formatted according to those formatting rules...

Let me know if anything is missing. If this lands, I would appreciated a new version to be used in my own project.