### PR TITLE
Fix monomials for LexOrder

### DIFF
--- a/src/monomial_vector.jl
+++ b/src/monomial_vector.jl
@@ -186,7 +186,7 @@ function _fill_noncomm_exponents_rec!(Z, z, i, n, deg, ::Type{MP.LexOrder}, filt
     else
         for i in i:i+n-1
             z[i] += 1
-            fillZrec!(Z, z, i, n, deg - 1, LexOrder, filter)
+            _fill_noncomm_exponents_rec!(Z, z, i, n, deg - 1, LexOrder, filter)
             z[i] -= 1
         end
     end
@@ -205,7 +205,7 @@ function _fill_exponents!(
     _error_for_negative_degree(maxdeg)
     z = zeros(Int, maxdeg * n - maxdeg + 1)
     start = length(Z) + 1
-    fillZrec!(Z, z, 1, n, deg, M, filter)
+    _fill_noncomm_exponents_rec!(Z, z, 1, n, deg, M, filter)
     return reverse!(view(Z, start:length(Z)))
 end
 

--- a/src/monomial_vector.jl
+++ b/src/monomial_vector.jl
@@ -205,7 +205,7 @@ function _fill_exponents!(
     _error_for_negative_degree(maxdeg)
     z = zeros(Int, maxdeg * n - maxdeg + 1)
     start = length(Z) + 1
-    _fill_noncomm_exponents_rec!(Z, z, 1, n, deg, M, filter)
+    _fill_noncomm_exponents_rec!(Z, z, 1, n, deg, MP.LexOrder, filter)
     return reverse!(view(Z, start:length(Z)))
 end
 

--- a/test/comp.jl
+++ b/test/comp.jl
@@ -44,3 +44,19 @@ end
     @test ordering(x[1]) == order
     @test issorted(monomials(x[1], 0:2))
 end
+
+function _test_less(a, b)
+    @test a < b
+    @test b > a
+end
+
+@testset "LexOrder" begin
+    @polyvar x y monomial_order = LexOrder
+    _test_less(y, y^2)
+    _test_less(x^0, y)
+    _test_less(y^2, x)
+    _test_less(x * y^2, x^2)
+    @test monomials([x, y], 3) == [y^3, y^2 * x, y * x^2, x^3]
+    @test monomials([x, y], 1:2) == [y, y^2, x, x * y, x^2]
+    @test monomials([x, y], [0, 1, 3]) == [1, y, y^3, x, y^2 * x, y * x^2, x^3]
+end

--- a/test/comp.jl
+++ b/test/comp.jl
@@ -50,13 +50,59 @@ function _test_less(a, b)
     @test b > a
 end
 
+function _test_monomials(vars, degs, exp)
+    # Without `collect`, `exp` is promoted to a `MonomialVector`
+    # which sorts it so it doesn't test the order
+    @test collect(monomials(vars, degs)) == exp
+end
+
 @testset "LexOrder" begin
     @polyvar x y monomial_order = LexOrder
     _test_less(y, y^2)
     _test_less(x^0, y)
     _test_less(y^2, x)
     _test_less(x * y^2, x^2)
-    @test monomials([x, y], 3) == [y^3, y^2 * x, y * x^2, x^3]
-    @test monomials([x, y], 1:2) == [y, y^2, x, x * y, x^2]
-    @test monomials([x, y], [0, 1, 3]) == [1, y, y^3, x, y^2 * x, y * x^2, x^3]
+    _test_monomials([x, y], 3, [y^3, y^2 * x, y * x^2, x^3])
+    _test_monomials([x, y], 1:2, [y, y^2, x, x * y, x^2])
+    _test_monomials([x, y], [0, 1, 3], [1, y, y^3, x, y^2 * x, y * x^2, x^3])
+end
+
+@testset "InverseLexOrder" begin
+    @polyvar x y monomial_order = InverseLexOrder
+    _test_less(y, y^2)
+    _test_less(x^0, y)
+    _test_less(x, y^2)
+    _test_less(x^2, x * y^2)
+    _test_monomials([x, y], 3, [x^3, x^2 * y, x * y^2, y^3])
+end
+
+@testset "Reverse{LexOrder}" begin
+    @polyvar x y monomial_order = Reverse{LexOrder}
+    _test_less(y^2, y)
+    _test_less(y, x^0)
+    _test_less(x, y^2)
+    _test_less(x^2, x * y^2)
+    _test_monomials([x, y], 3, [x^3, x^2 * y, x * y^2, y^3])
+end
+
+@testset "Reverse{InverseLexOrder}" begin
+    @polyvar x y monomial_order = Reverse{InverseLexOrder}
+    _test_less(y^2, y)
+    _test_less(y, x^0)
+    _test_less(y^2, x)
+    _test_less(x * y^2, x^2)
+    _test_monomials([x, y], 3, [y^3, y^2 * x, y * x^2, x^3])
+    _test_monomials([x, y], 1:2, [y^2, x * y, y, x^2, x])
+    _test_monomials([x, y], [0, 1, 3], [y^3, x*y^2, x^2*y, y, x^3, x, 1])
+end
+
+@testset "Graded{Reverse{InverseLexOrder}}" begin
+    @polyvar x y monomial_order = Graded{Reverse{InverseLexOrder}}
+    _test_less(y, y^2)
+    _test_less(x^0, y)
+    _test_less(x, y^2)
+    _test_less(x^2, x * y^2)
+    _test_monomials([x, y], 3, [y^3, y^2 * x, y * x^2, x^3])
+    _test_monomials([x, y], 1:2, [y, x, y^2, x * y, x^2])
+    _test_monomials([x, y], [0, 1, 3], [1, y, x, y^3, x*y^2, x^2*y, x^3])
 end


### PR DESCRIPTION
All orders should hopefully work now. The `Reverse` that are not `Graded` should probably not be allowed but let's wait to see what breaks since this ship has sailed

Closes https://github.com/JuliaAlgebra/DynamicPolynomials.jl/issues/138