### PR TITLE
Remove `Pkg` from dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
 MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 


### PR DESCRIPTION
Not sure why it's there, and no `using Pkg` or `import Pkg` statements seem to exist in the repo.